### PR TITLE
Fix map value not deep-copied under zero key

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -217,7 +217,7 @@ func cloneNested(ctx *cloneCtx, v reflect.Value) error {
 			}
 			v := iter.Value()
 			// if value needs to be copied, copy it recursively
-			if !valueIsBasic && !k.IsZero() {
+			if !valueIsBasic && !v.IsZero() {
 				newV.Set(v)
 				if err := cloneNested(ctx, newV); err != nil {
 					return err

--- a/clone_test.go
+++ b/clone_test.go
@@ -566,3 +566,43 @@ func TestEmptyStructPtrsShareSameAddress(t *testing.T) {
 	assert.NotNil(t, got.a)
 	assert.NotNil(t, got.b)
 }
+
+// TestCloneMapValueUnderZeroKey guards against a regression where the decision
+// to deep copy a map value was driven by the key's zero-ness instead of the
+// value's. Under a zero key (e.g. "", 0, nil) the value used to be left
+// aliased to the source, so mutating the clone leaked into the original.
+func TestCloneMapValueUnderZeroKey(t *testing.T) {
+	t.Run("zero string key", func(t *testing.T) {
+		m := map[string][]int{"": {1, 2, 3}}
+
+		cp, err := kamino.Clone(m)
+		assert.NoError(t, err)
+		assert.Equal(t, m, cp)
+
+		cp[""][0] = 999
+		assert.Equal(t, 1, m[""][0], "clone must not share underlying array with source")
+	})
+
+	t.Run("zero int key", func(t *testing.T) {
+		m := map[int][]int{0: {1, 2, 3}}
+
+		cp, err := kamino.Clone(m)
+		assert.NoError(t, err)
+		assert.Equal(t, m, cp)
+
+		cp[0][0] = 999
+		assert.Equal(t, 1, m[0][0], "clone must not share underlying array with source")
+	})
+
+	t.Run("zero pointer key", func(t *testing.T) {
+		var nilKey *int
+		m := map[*int][]int{nilKey: {1, 2, 3}}
+
+		cp, err := kamino.Clone(m)
+		assert.NoError(t, err)
+		assert.Equal(t, m, cp)
+
+		cp[nilKey][0] = 999
+		assert.Equal(t, 1, m[nilKey][0], "clone must not share underlying array with source")
+	})
+}


### PR DESCRIPTION
  Title:
  Fix map value not deep-copied under zero key

  Description:
  ## Summary

  The `reflect.Map` branch in `cloneNested` decided whether to deep-copy a
  map **value** based on the **key's** zero-ness (`!k.IsZero()`) instead of
  the value's. When a map entry had a zero key (`""`, `0`, a nil pointer,
  etc.), its value was left aliased to the source — so mutating the clone
  leaked back into the original, silently violating the core deep-copy
  guarantee.

  ```go
  m := map[string][]int{"": {1, 2, 3}}
  cp, _ := kamino.Clone(m)
  cp[""][0] = 999
  // before: m[""][0] == 999  ❌ (shared underlying array)
  // after:  m[""][0] == 1    ✅

  Change

  - clone.go: use !v.IsZero() instead of !k.IsZero() when deciding to
  deep-copy a map value.

  Tests

  - Added TestCloneMapValueUnderZeroKey covering zero string, int and nil
  pointer keys, asserting the clone does not share the underlying array
  with the source.
  - go test ./... and go vet ./... pass.