### PR TITLE
Speed up array cloning and harden edge cases

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -1,10 +1,16 @@
 package kamino
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"unsafe"
 )
+
+// ErrUnsupportedType is returned (wrapped) by Clone when WithErrOnUnsupported
+// is enabled and a value of an unsupported kind (chan or func) is encountered.
+// Use errors.Is to test for it.
+var ErrUnsupportedType = errors.New("kamino: unsupported type")
 
 type config struct {
 	expectedPointersCount int
@@ -18,6 +24,9 @@ type funcOptions func(*config)
 // If the amount of pointers in the source object is known and rather big, this setting could reduce allocations and improve performance.
 func WithExpectedPtrsCount(cnt int) func(*config) {
 	return func(c *config) {
+		if cnt < 0 {
+			cnt = 0
+		}
 		c.expectedPointersCount = cnt
 	}
 }
@@ -109,8 +118,15 @@ func Clone[T any](src T, opts ...funcOptions) (T, error) {
 
 func cloneNested(ctx *cloneCtx, v reflect.Value) error {
 	kind := v.Kind()
-	// check if the value should be copied, i.e. it's neither of basic type, nor zero
-	if isBasicKind(kind) || v.IsZero() {
+	// basic kinds are already fully copied by value, nothing to do
+	if isBasicKind(kind) {
+		return nil
+	}
+	// for nil-able kinds skip the work (and avoid dereferencing nil pointers /
+	// turning nil slices and maps into empty non-nil ones).
+	// struct and array are intentionally excluded here: IsZero recurses over
+	// every field/element, duplicating the traversal we are about to do anyway.
+	if kind != reflect.Struct && kind != reflect.Array && v.IsZero() {
 		return nil
 	}
 	//  handle according to original's Kind
@@ -148,27 +164,18 @@ func cloneNested(ctx *cloneCtx, v reflect.Value) error {
 			}
 		}
 	case reflect.Array:
-		// for arrays allocate the new one of the elem type
-		elem := v.Type().Elem()
-		res := reflect.New(reflect.ArrayOf(v.Len(), elem)).Elem()
-		// and copy values from source at once
-		reflect.Copy(res, v)
-
-		// if an elem kind is basic just return
-		if isBasicKind(elem.Kind()) {
-			v.Set(res)
+		// arrays are value types, so v already holds a copy of the data.
+		// if the elem kind is basic there is nothing left to deep copy.
+		if isBasicKind(v.Type().Elem().Kind()) {
 			return nil
 		}
 
-		// otherwise recursively clone the elems
-		for i := 0; i < res.Len(); i++ {
-			if err := cloneNested(ctx, res.Index(i)); err != nil {
+		// otherwise recursively clone the elems in place
+		for i := 0; i < v.Len(); i++ {
+			if err := cloneNested(ctx, v.Index(i)); err != nil {
 				return err
 			}
 		}
-
-		// replace the source with the copy
-		v.Set(res)
 	case reflect.Slice:
 		// for slices allocate the new one of the elem type
 		typ := v.Type()
@@ -268,7 +275,7 @@ func cloneNested(ctx *cloneCtx, v reflect.Value) error {
 	default:
 		// if unsupported type strategy has been setted to err - return an error
 		if ctx.errOnUnsuported {
-			return fmt.Errorf("unsupported type: %s", v.Type().Name())
+			return fmt.Errorf("%w: %s", ErrUnsupportedType, v.Type())
 		}
 	}
 

--- a/clone_test.go
+++ b/clone_test.go
@@ -1,6 +1,7 @@
 package kamino_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -605,4 +606,43 @@ func TestCloneMapValueUnderZeroKey(t *testing.T) {
 		cp[nilKey][0] = 999
 		assert.Equal(t, 1, m[nilKey][0], "clone must not share underlying array with source")
 	})
+}
+
+// TestCloneArrayOfStructsIsIndependent guards the in-place array cloning path:
+// nested non-basic elements must be deep copied so mutating the clone does not
+// touch the source.
+func TestCloneArrayOfStructsIsIndependent(t *testing.T) {
+	type item struct {
+		S []int
+	}
+	src := [2]item{{S: []int{1, 2}}, {S: []int{3, 4}}}
+
+	cp, err := kamino.Clone(src)
+	assert.NoError(t, err)
+	assert.Equal(t, src, cp)
+
+	cp[0].S[0] = 999
+	assert.Equal(t, 1, src[0].S[0], "clone must not share underlying array with source")
+}
+
+// TestCloneNilContainersStayNil ensures nil slices/maps are not turned into
+// empty non-nil ones by the clone.
+func TestCloneNilContainersStayNil(t *testing.T) {
+	type holder struct {
+		S []int
+		M map[string]int
+	}
+
+	cp, err := kamino.Clone(holder{})
+	assert.NoError(t, err)
+	assert.Nil(t, cp.S)
+	assert.Nil(t, cp.M)
+}
+
+// TestErrUnsupportedTypeIsWrapped ensures the returned error matches the
+// exported sentinel via errors.Is.
+func TestErrUnsupportedTypeIsWrapped(t *testing.T) {
+	_, err := kamino.Clone(func() {}, kamino.WithErrOnUnsupported())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, kamino.ErrUnsupportedType))
 }


### PR DESCRIPTION
- Clone arrays in place instead of allocating a fresh array and copying into it: arrays are value types, so the traversed value already holds a copy. Removes one allocation per nested array.
- Skip the recursive IsZero() check for struct and array kinds at the top of cloneNested: IsZero walks every field/element, duplicating the traversal we are about to perform. Still applied to nil-able kinds so nil slices/maps stay nil and nil pointers are not dereferenced.
- Export ErrUnsupportedType and wrap it with %w so callers can match it via errors.Is; use Type() (full type string) in the message instead of the empty Name() of unnamed func/chan types.
- Clamp WithExpectedPtrsCount to a non-negative value to avoid a panic from make(map, negative).

Add regression tests for array-of-structs independence, nil container preservation, and the wrapped sentinel error.